### PR TITLE
Bump node.js to v12.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.17.0-jessie as builder
+FROM node:12 as builder
 WORKDIR /app
 
 ARG BUILD_COMMAND


### PR DESCRIPTION
Bump node to v12 since node.js v10 is going to be deprecated in April 2021.

See the release timeline of node.js: <https://nodejs.org/en/about/releases/>